### PR TITLE
Revert "Update URL for `pmc-vip-go-plugins`"

### DIFF
--- a/scripts/set-up-wordpress-dependencies.sh
+++ b/scripts/set-up-wordpress-dependencies.sh
@@ -36,7 +36,7 @@ if [[ -f "${WP_CONTENT_TARGET_DIR}/plugins/README.md" ]]; then
   rm -rf "${WP_CONTENT_TARGET_DIR}/plugins"
 fi
 
-git_checkout "${WP_CONTENT_TARGET_DIR}/plugins" git@github.com:penske-media-corp/pmc-vip-go-plugins.git 1
+git_checkout "${WP_CONTENT_TARGET_DIR}/plugins" git@bitbucket.org:penskemediacorp/pmc-vip-go-plugins.git 1
 
 # Install pmc-plugins and parent theme.
 if [[ -z "${PMC_IS_PMC_PLUGINS}" ]]; then


### PR DESCRIPTION
There are hardcoded references to `master` that need to be fixed.

Reverts penske-media-corp/github-action-wordpress-test-setup#4