### PR TITLE
Update URL for `pmc-vip-go-plugins`

### DIFF
--- a/bin/pmc-test-functions
+++ b/bin/pmc-test-functions
@@ -15,7 +15,7 @@ function git_switch_to_master_if_branch_not_exist {
 		if [[ -n "${REMOTE_BRANCH}" ]]; then
 			git checkout ${BRANCH}
 		else
-			git checkout master
+			git checkout $(pmc_get_git_default_branch ${GIT_REMOTE})
 		fi
 		git pull
 	fi
@@ -144,14 +144,14 @@ function git_checkout {
   echo_info "git checkout ${TARGET}"
   mkdir -p ${TARGET}
   pushd ${TARGET} 2>&1 > /dev/null
-ls -lah
+
   git config --global --add safe.directory $( pwd )
 
   if [ ! -d ${TARGET}/.git ]; then
     if [[ -z "${DEPTH}" || "0" == "${DEPTH}" ]]; then
       git clone --quiet --recursive --bare ${SOURCE} .git
     else
-      git clone --quiet -b master --depth ${DEPTH} --recursive --bare ${SOURCE} .git
+      git clone --quiet -b $(pmc_get_git_default_branch ${SOURCE}) --depth ${DEPTH} --recursive --bare ${SOURCE} .git
     fi
     git config --unset core.bare
     git reset --hard

--- a/bin/pmc-test-functions
+++ b/bin/pmc-test-functions
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+. pmc-functions
+
 function git_switch_to_master_if_branch_not_exist {
 	local BRANCH="$1"
 	local FOLDER="$2"

--- a/scripts/set-up-wordpress-dependencies.sh
+++ b/scripts/set-up-wordpress-dependencies.sh
@@ -36,7 +36,7 @@ if [[ -f "${WP_CONTENT_TARGET_DIR}/plugins/README.md" ]]; then
   rm -rf "${WP_CONTENT_TARGET_DIR}/plugins"
 fi
 
-git_checkout "${WP_CONTENT_TARGET_DIR}/plugins" git@bitbucket.org:penskemediacorp/pmc-vip-go-plugins.git 1
+git_checkout "${WP_CONTENT_TARGET_DIR}/plugins" git@github.com:penske-media-corp/pmc-vip-go-plugins.git 1
 
 # Install pmc-plugins and parent theme.
 if [[ -z "${PMC_IS_PMC_PLUGINS}" ]]; then


### PR DESCRIPTION
Restores #4, reverted in #5 due to hardcoded default branch