### PR TITLE
Update pmc-test-npm

### DIFF
--- a/bin/pmc-test-npm
+++ b/bin/pmc-test-npm
@@ -27,7 +27,7 @@ pmc_run_npmtest() {
 
 				nvm install
 				nvm use
-				if [[ $( npm run | grep 'test' ) ]]; then
+				if [[ $( npm run | egrep '(^|[[:space:]])test($|[[:space:]]])' ) ]]; then
 					npm config set unsafe-perm true
 					npm config set user 0
 					npm ci


### PR DESCRIPTION
Update command below which checks to see if `npm run test` exists in packages.json
From
`npm run | grep test` 
To
egrep '(^|[[:space:]])test($|[[:space:]]])' 

egrep above excludes lines such as below so that pmc-test-npm won't unexpectedly run `npm ci` and `npm run test`

```
SSPATH=./tests/qat/screenshots/ mocha ./tests/qat/*.spec.js --exit
npm install @penskemediacorp/larva@latest
```