### PR TITLE
Bugfix: Avoid running JS unit tests in plugins that were removed

### DIFF
--- a/bin/pmc-test-npm
+++ b/bin/pmc-test-npm
@@ -64,6 +64,8 @@ then
 				pushd ${i}
 				pmc_run_npmtest
 				popd
+			else
+				echo "\033[31mWARNING:\033[0m ${i} does not appear to exist. Skipping tests."
 			fi
 		done
 	fi

--- a/bin/pmc-test-npm
+++ b/bin/pmc-test-npm
@@ -65,7 +65,7 @@ then
 				pmc_run_npmtest
 				popd
 			else
-				echo "\033[31mWARNING:\033[0m ${i} does not appear to exist. Skipping tests."
+				echo "WARNING: ${i} does not appear to exist. Skipping tests."
 			fi
 		done
 	fi

--- a/bin/pmc-test-npm
+++ b/bin/pmc-test-npm
@@ -59,9 +59,12 @@ then
 		# potential errors
 		for i in "${PMC_PLUGINS_JS_CHECKLIST[@]}"
 		do
-			pushd ${i}
-			pmc_run_npmtest
-			popd
+			if [[ -d "${i}" ]]
+			then
+				pushd ${i}
+				pmc_run_npmtest
+				popd
+			fi
 		done
 	fi
 else


### PR DESCRIPTION
When `pmc-test-npm` sees [a changed JS file](https://github.com/penske-media-corp/pmc-plugins/actions/runs/7350470883/job/20012189423#step:3:104), [it tries to execute the JS unit tests for the plugin it's in](https://github.com/penske-media-corp/github-action-wordpress-test-setup/blob/main/bin/pmc-test-npm#L55-L66). However, if an entire plugin containing JS files is removed from `pmc-plugins` (for example), the script considers that a change and attempts to [run actions on it](https://github.com/penske-media-corp/github-action-wordpress-test-setup/blob/main/bin/pmc-test-npm#L62-L64), which fails ([example](https://github.com/penske-media-corp/pmc-plugins/actions/runs/7350470883/job/20012189423#step:3:164)] because the directory is now missing.

This change adds a directory check to the script so it doesn't try to execute tests in a removed plugin, logging a warning message if so.