### PR TITLE
Fail PHPCS pipeline if PHPCS doesn't generate a report

### DIFF
--- a/bin/pmc-test-phpcs
+++ b/bin/pmc-test-phpcs
@@ -50,6 +50,14 @@ pmc_run_phpcs() {
 				${PHPCS_BIN} -s --report=json --report-json=/tmp/phpcs.json ${PHPCS_FILES[*]}
 			fi
 
+			set -e
+			if [[ ! -f /tmp/phpcs.json ]]
+				then
+					echo -e "${RED}${ERROR}${RESET} PHPCS failed to generate a report."
+					return 1
+			fi
+			set +e
+
 			if [[ -f /tmp/diffFilter.log ]]
 				then
 					rm -f /tmp/diffFilter.log


### PR DESCRIPTION
A fatal error in a custom sniff prevented the PHPCS JSON report from being generated, but because of the `set +e` at the start of `pmc_run_phpcs`, the workflow didn't fail, instead ending with the message `Can't Parse phpcs json - Syntax error`.