### PR TITLE
Use Jetpack version supported by current WordPress version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -248,8 +248,11 @@ runs:
         WP_CONFIG_PATH="${WP_TESTS_DIR}/wp-tests-config.php"
 
         echo "define( 'IS_UNIT_TEST', true );" >> "${WP_CONFIG_PATH}"
+        echo "define( 'WPCOM_VIP_JETPACK_LOCAL', true );" >> "${WP_CONFIG_PATH}"
 
         sed -i 's/example\.org/pmcdev\.local/g' "${WP_CONFIG_PATH}"
+
+        cat "${WP_CONFIG_PATH}"
       shell: bash
 
     # Prepare for PHPCS

--- a/action.yml
+++ b/action.yml
@@ -251,8 +251,6 @@ runs:
         echo "define( 'WPCOM_VIP_JETPACK_LOCAL', true );" >> "${WP_CONFIG_PATH}"
 
         sed -i 's/example\.org/pmcdev\.local/g' "${WP_CONFIG_PATH}"
-
-        cat "${WP_CONFIG_PATH}"
       shell: bash
 
     # Prepare for PHPCS

--- a/scripts/set-up-wordpress-dependencies.sh
+++ b/scripts/set-up-wordpress-dependencies.sh
@@ -8,11 +8,6 @@ WP_CONTENT_TARGET_DIR="${WP_CORE_DIR}/wp-content"
 # Modify `wp-tests-config.php`.
 WP_CONFIG_PATH="${WP_TESTS_DIR}/wp-tests-config.php"
 
-if [[ ! -n "$(grep 'WPCOM_VIP_JETPACK_LOCAL' "${WP_CONFIG_PATH}")" ]]; then
-  echo "define( 'WPCOM_VIP_JETPACK_LOCAL', true );
-" >> "${WP_CONFIG_PATH}"
-fi
-
 if [[ ! -n "$(grep '000-pre-vip-config/requires.php' "${WP_CONFIG_PATH}")" ]]; then
   VIP_GO_REQUIRES_ADDITION="// Load VIP's additional requirements.
 if ( file_exists( ABSPATH . '/wp-content/mu-plugins/000-pre-vip-config/requires.php' ) ) {
@@ -21,8 +16,6 @@ if ( file_exists( ABSPATH . '/wp-content/mu-plugins/000-pre-vip-config/requires.
 "
   echo "${VIP_GO_REQUIRES_ADDITION}" >> "${WP_CONFIG_PATH}"
 fi
-
-cat "${WP_CONFIG_PATH}"
 
 # Install client-mu-plugins.
 if [[ ! -d "${WP_CONTENT_TARGET_DIR}/client-mu-plugins" ]]; then

--- a/scripts/set-up-wordpress-dependencies.sh
+++ b/scripts/set-up-wordpress-dependencies.sh
@@ -24,8 +24,8 @@ fi
 mv "${RUNNER_TEMP}/plugin-loader.php" "${WP_CONTENT_TARGET_DIR}/client-mu-plugins/plugin-loader.php"
 
 if [[ ! -d "${WP_CONTENT_TARGET_DIR}/client-mu-plugins/jetpack" ]]; then
-  curl -o /tmp/jetpack-14.0.zip https://downloads.wordpress.org/plugin/jetpack.14.0.zip
-  unzip /tmp/jetpack-14.0.zip -d "${WP_CONTENT_TARGET_DIR}/client-mu-plugins"
+  curl --no-progress-meter -o /tmp/jetpack-14.0.zip https://downloads.wordpress.org/plugin/jetpack.14.0.zip
+  unzip -q /tmp/jetpack-14.0.zip -d "${WP_CONTENT_TARGET_DIR}/client-mu-plugins"
 fi
 
 # Install VIP Go's mu-plugins.

--- a/scripts/set-up-wordpress-dependencies.sh
+++ b/scripts/set-up-wordpress-dependencies.sh
@@ -8,6 +8,11 @@ WP_CONTENT_TARGET_DIR="${WP_CORE_DIR}/wp-content"
 # Modify `wp-tests-config.php`.
 WP_CONFIG_PATH="${WP_TESTS_DIR}/wp-tests-config.php"
 
+if [[ ! -n "$(grep 'WPCOM_VIP_JETPACK_LOCAL' "${WP_CONFIG_PATH}")" ]]; then
+  echo "define( 'WPCOM_VIP_JETPACK_LOCAL', true );
+" >> "${WP_CONFIG_PATH}"
+fi
+
 if [[ ! -n "$(grep '000-pre-vip-config/requires.php' "${WP_CONFIG_PATH}")" ]]; then
   VIP_GO_REQUIRES_ADDITION="// Load VIP's additional requirements.
 if ( file_exists( ABSPATH . '/wp-content/mu-plugins/000-pre-vip-config/requires.php' ) ) {

--- a/scripts/set-up-wordpress-dependencies.sh
+++ b/scripts/set-up-wordpress-dependencies.sh
@@ -23,6 +23,11 @@ if [[ ! -d "${WP_CONTENT_TARGET_DIR}/client-mu-plugins" ]]; then
 fi
 mv "${RUNNER_TEMP}/plugin-loader.php" "${WP_CONTENT_TARGET_DIR}/client-mu-plugins/plugin-loader.php"
 
+if [[ ! -d "${WP_CONTENT_TARGET_DIR}/client-mu-plugins/jetpack" ]]; then
+  curl -o /tmp/jetpack-14.0.zip https://downloads.wordpress.org/plugin/jetpack.14.0.zip
+  unzip /tmp/jetpack-14.0.zip -d "${WP_CONTENT_TARGET_DIR}/client-mu-plugins"
+fi
+
 # Install VIP Go's mu-plugins.
 git_checkout "${WP_CONTENT_TARGET_DIR}/mu-plugins" https://github.com/Automattic/vip-go-mu-plugins-built.git 1
 

--- a/scripts/set-up-wordpress-dependencies.sh
+++ b/scripts/set-up-wordpress-dependencies.sh
@@ -22,6 +22,8 @@ if ( file_exists( ABSPATH . '/wp-content/mu-plugins/000-pre-vip-config/requires.
   echo "${VIP_GO_REQUIRES_ADDITION}" >> "${WP_CONFIG_PATH}"
 fi
 
+cat "${WP_CONFIG_PATH}"
+
 # Install client-mu-plugins.
 if [[ ! -d "${WP_CONTENT_TARGET_DIR}/client-mu-plugins" ]]; then
   mkdir "${WP_CONTENT_TARGET_DIR}/client-mu-plugins"


### PR DESCRIPTION
VIP's policy is to support the latest two versions of Jetpack, but neither of those support the version of WordPress we're using. On the VIP platform, they load the correct version for us, so we need to load a specific version in our GitHub workflows.