### PR TITLE
Updating action to use composer 2.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -187,7 +187,7 @@ runs:
       with:
         php-version: ${{ inputs.php_version }}
         coverage: ${{ steps.php-coverage-mode.outputs.mode }}
-        tools: composer:1
+        tools: composer:v2
 
     - name: Log debug information
       if: ${{ inputs.phpcs == '1' || inputs.phpunit == '1' }}


### PR DESCRIPTION
> Warning from [https://repo.packagist.org:](https://repo.packagist.org/) Support for Composer 1 has been shutdown on September 1st 2025. You should upgrade to Composer 2. See https://blog.packagist.com/shutting-down-packagist-org-support-for-composer-1-x/